### PR TITLE
fix: useStore: generic & argument types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 types
 dist
+.idea
 
 .yarn/*
 !.yarn/cache

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-    env: {
-      test: {
-        presets: [["@babel/preset-env", { targets: { node: "current" } }], "@babel/preset-typescript"]
-      }
-    }
-};

--- a/package.json
+++ b/package.json
@@ -4,19 +4,18 @@
   "description": "Global state management in Solid using nanostores.",
   "type": "module",
   "files": [
-    "dist"
+    "src"
   ],
-  "main": "dist/esm/solid-nanostores.js",
-  "module": "dist/esm/solid-nanostores.js",
-  "types": "dist/types/solid-nanostores.d.ts",
+  "module": "src/index.js",
+  "types": "src/index.d.ts",
   "exports": {
     ".": {
-      "solid": "./dist/source/solid-nanostores.js",
-      "default": "./dist/esm/solid-nanostores.js"
+      "solid": "src/index.js",
+      "default": "src/index.js"
     }
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": ":",
     "prepublishOnly": "yarn build",
     "test": "jest"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,0 @@
-import withSolid from 'rollup-preset-solid';
-
-export default withSolid({
-  input: 'src/solid-nanostores.ts',
-  printInstructions: true
-});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+export * from './solid-nanostores'

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+export * from './solid-nanostores.js'

--- a/src/solid-nanostores.d.ts
+++ b/src/solid-nanostores.d.ts
@@ -1,0 +1,4 @@
+import { ReadableAtom } from 'nanostores';
+import { Store } from 'solid-js/store';
+
+export function useStore<Value>(store: ReadableAtom<Value>):Store<Value>;

--- a/src/solid-nanostores.js
+++ b/src/solid-nanostores.js
@@ -1,8 +1,7 @@
-import { createStore, reconcile, StoreNode } from 'solid-js/store';
+import { createStore, reconcile } from 'solid-js/store';
 import { onCleanup } from 'solid-js';
-import { ReadableAtom } from 'nanostores';
 
-export function useStore<T extends StoreNode>(store: ReadableAtom<T>) {
+export function useStore(store) {
   const [state, setState] = createStore(store.get());
   const unsubscribe = store.subscribe((newState) => {
     setState(reconcile(newState))


### PR DESCRIPTION
removed build step: .js + .d.ts

Following the same file structure patterns as in the nanostore project. The typescript build did not seem necessary.

Also added `useSignal`