### PR TITLE
fix: update peer deps to avoid npm errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/nanostores/solid#readme",
   "peerDependencies": {
-    "nanostores": "^0.7.0",
+    "nanostores": "^0.8.0",
     "solid-js": ">=1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`nanostores@^0.8.0` is causing npm to throw peer deps errors. This bumps the peer dep to the latest release to avoid these errors.