### PR TITLE
chore: update nanostores versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0",
+    "nanostores": ">=0.9.0 <2.0.0",
     "solid-js": "^1.6.0"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "eslint-plugin-no-only-tests": "^3.1.0",
     "jsdom": "^22.0.0",
     "nanodelay": "^2.0.2",
-    "nanostores": "^0.11.3",
+    "nanostores": "^1.0.1",
     "prettier": "3.0.0",
     "solid-js": "^1.9.1",
     "tsup": "^8.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       nanostores:
-        specifier: ^0.11.3
-        version: 0.11.3
+        specifier: ^1.0.1
+        version: 1.0.1
       prettier:
         specifier: 3.0.0
         version: 3.0.0
@@ -1558,9 +1558,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanostores@0.11.3:
-    resolution: {integrity: sha512-TUes3xKIX33re4QzdxwZ6tdbodjmn3tWXCEc1uokiEmo14sI1EaGYNs2k3bU2pyyGNmBqFGAVl6jAGWd06AVIg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  nanostores@1.0.1:
+    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3774,7 +3774,7 @@ snapshots:
 
   nanoid@3.3.7: {}
 
-  nanostores@0.11.3: {}
+  nanostores@1.0.1: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
Resolves https://github.com/nanostores/solid/issues/23.

- Updates and simplifies the `nanostores` `peerDependency` to allow for version `1.0`.
- Updates the `nanostores` `devDependency` to the latest version (`^1.0.1`).