### PR TITLE
fix: add `key` option to `useStore()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { onCleanup } from 'solid-js'
  */
 export function useStore<SomeStore extends Store, Value extends StoreValue<SomeStore>>(
   store: SomeStore,
+  options: { key?: string | null } = {},
 ): Accessor<Value> {
   // Activate the store explicitly:
   // https://github.com/nanostores/solid/issues/19
@@ -21,7 +22,8 @@ export function useStore<SomeStore extends Store, Value extends StoreValue<SomeS
   })
 
   const unsubscribe = store.subscribe(newValue => {
-    setState('value', reconcile(newValue))
+    // Specify the key for reconciliation to match items in array store.
+    setState('value', reconcile(newValue, { key: options.key }))
   })
 
   onCleanup(() => unsubscribe())


### PR DESCRIPTION
Resolves https://github.com/nanostores/solid/issues/25.

The `key` option allows us to specify the key for reconciliation to match items in array store.

consistent with `reconcile()` in `solid-js/store`.

Add 2 testing cases into `src/index.test.tsx`.
